### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -49,7 +49,7 @@
         <commons-lang.version>2.6</commons-lang.version>
         <commons-beanutils.version>1.9.2</commons-beanutils.version>
         <commons-logging.version>1.2</commons-logging.version>
-        <commons-collections.version>3.2.1</commons-collections.version>
+        <commons-collections.version>3.2.2</commons-collections.version>
         <commons-codes.version>1.10</commons-codes.version>
         <commons-fileupload.version>1.3.1</commons-fileupload.version>
         <commons-httpclient.version>3.1</commons-httpclient.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
